### PR TITLE
Replace 3 with q3

### DIFF
--- a/main.py
+++ b/main.py
@@ -527,7 +527,7 @@ def risFormat(risRecords, ind):
                                 if ind == 9:
                                     q2 = textL.find('Issue Info:') - 2
                                     q3 = textL[q1:q2+2].find('; ')
-                                    qd = q1 + 3
+                                    qd = q1 + q3
                                     setattr(newDoc, 'corrAuth',
                                             beTe + "; " + textL[q1:qd])
                                 # EBSCO


### PR DESCRIPTION
Otherwise the previously defined variable q3 is not used.

This error was found by lgtm: https://lgtm.com/projects/g/tuub/oa-eval/alerts/?mode=tree&ruleFocus=1800095 .